### PR TITLE
Nil out non-utf8 valid values. Closes #9

### DIFF
--- a/lib/emailbutler/helpers.rb
+++ b/lib/emailbutler/helpers.rb
@@ -23,7 +23,7 @@ module Emailbutler
 
     def serialize_value(value)
       return value.to_global_id.to_s if value.respond_to?(:to_global_id)
-      return nil unless value&.valid_encoding?
+      return if value.is_a?(String) && !value&.valid_encoding?
 
       value
     end

--- a/lib/emailbutler/helpers.rb
+++ b/lib/emailbutler/helpers.rb
@@ -23,6 +23,7 @@ module Emailbutler
 
     def serialize_value(value)
       return value.to_global_id.to_s if value.respond_to?(:to_global_id)
+      return nil unless value&.valid_encoding?
 
       value
     end


### PR DESCRIPTION
This seems to fix the issue we had trying to add this Gem to our project. I also tried using a method to convert to utf8:
```
def convert_to_utf8(value)
  # Source: https://stackoverflow.com/a/30649766
  value&.encode(Encoding.find('UTF-8'), invalid: :replace, undef: :replace, replace: '')
end
```

but that caused another error down the line:
```
 ActiveRecord::StatementInvalid:
            PG::UntranslatableCharacter: ERROR:  unsupported Unicode escape sequence
```

so I'd prefer to just set these types of values to `nil`.